### PR TITLE
Allow tests to run on windows without relying on sh like environment

### DIFF
--- a/mocha.js
+++ b/mocha.js
@@ -1,0 +1,29 @@
+var Mocha = require('mocha'),
+    fs = require('fs'),
+    path = require('path');
+
+// Instantiate a Mocha instance.
+var mocha = new Mocha({
+    ui: 'bdd',
+    reporter: 'nyan'
+});
+
+var testDir = 'tests/app'
+
+// Add each .js file to the mocha instance
+fs.readdirSync(testDir).filter(function(file){
+    // Only keep the .js files
+    return file.endsWith('.js')
+
+}).forEach(function(file){
+    mocha.addFile(
+        path.join(testDir, file)
+    );
+});
+
+// Run the tests.
+mocha.run(function(failures){
+  process.on('exit', function () {
+    process.exit(failures);  // exit with non-zero status if there were failures
+  });
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "start": "node bin/serve",
-    "test": "./node_modules/mocha/bin/mocha -R spec tests/runner.js"
+    "test": "node mocha.js"
   },
   "bin" : "bin/serve",
   "bugs" : {


### PR DESCRIPTION
Currently the npm script to run the tests relies on a unix-like environment to work. This could cause confusion for candidates.