### PR TITLE
Return chai .ok to working order. Fix eslint to be ok with it

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,5 +17,11 @@ module.exports = {
     },
     "rules": {
         "linebreak-style": 0,
-    }
+        "no-unused-expressions": 0,
+        "chai-friendly/no-unused-expressions": 2
+    },
+    "plugins": [
+        "chai-friendly"
+    ]
+
 };

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "eslint": "^4.2.0",
     "eslint-config-airbnb-base": "^11.2.0",
+    "eslint-plugin-chai-friendly": "^0.3.6",
     "eslint-plugin-import": "^2.7.0"
   }
 }

--- a/tests/app/flowControl.js
+++ b/tests/app/flowControl.js
@@ -6,8 +6,8 @@ describe('flow control', () => {
       num = Math.floor(Math.random() * 10) + 1;
     }
 
-    expect(flowControlAnswers.fizzBuzz()).not.to.be.ok();
-    expect(flowControlAnswers.fizzBuzz('foo')).not.to.be.ok();
+    expect(flowControlAnswers.fizzBuzz()).not.to.be.ok;
+    expect(flowControlAnswers.fizzBuzz('foo')).not.to.be.ok;
     expect(flowControlAnswers.fizzBuzz(2)).to.eql(2);
     expect(flowControlAnswers.fizzBuzz(101)).to.eql(101);
 

--- a/tests/app/functions.js
+++ b/tests/app/functions.js
@@ -12,7 +12,7 @@ describe('functions', () => {
   it('you should be able to use an array as arguments when calling a function', () => {
     const result = functionsAnswers.argsAsArray(sayIt, ['Hello', 'Ellie', '!']);
     expect(result).to.eql('Hello, Ellie!');
-    expect(sayItCalled).to.be.ok();
+    expect(sayItCalled).to.be.ok;
   });
 
   it('you should be able to return a function from a function', () => {

--- a/tests/app/logicalOperators.js
+++ b/tests/app/logicalOperators.js
@@ -1,17 +1,17 @@
 describe('logical operators', () => {
   it('you should be able to work with logical or', () => {
-    expect(logicalOperatorsAnswers.or(false, true)).to.be.ok();
-    expect(logicalOperatorsAnswers.or(true, false)).to.be.ok();
-    expect(logicalOperatorsAnswers.or(true, true)).to.be.ok();
-    expect(logicalOperatorsAnswers.or(false, false)).not.to.be.ok();
+    expect(logicalOperatorsAnswers.or(false, true)).to.be.ok;
+    expect(logicalOperatorsAnswers.or(true, false)).to.be.ok;
+    expect(logicalOperatorsAnswers.or(true, true)).to.be.ok;
+    expect(logicalOperatorsAnswers.or(false, false)).not.to.be.ok;
     expect(logicalOperatorsAnswers.or(3, 4)).to.not.eq(7);
   });
 
   it('you should be able to work with logical and', () => {
-    expect(logicalOperatorsAnswers.and(false, true)).not.to.be.ok();
-    expect(logicalOperatorsAnswers.and(false, false)).not.to.be.ok();
-    expect(logicalOperatorsAnswers.and(true, false)).not.to.be.ok();
-    expect(logicalOperatorsAnswers.and(true, true)).to.be.ok();
-    expect(logicalOperatorsAnswers.and(3, 4)).to.be.ok();
+    expect(logicalOperatorsAnswers.and(false, true)).not.to.be.ok;
+    expect(logicalOperatorsAnswers.and(false, false)).not.to.be.ok;
+    expect(logicalOperatorsAnswers.and(true, false)).not.to.be.ok;
+    expect(logicalOperatorsAnswers.and(true, true)).to.be.ok;
+    expect(logicalOperatorsAnswers.and(3, 4)).to.be.ok;
   });
 });

--- a/tests/app/recursion.js
+++ b/tests/app/recursion.js
@@ -35,16 +35,16 @@ describe('recursion', () => {
   it('you should be able to return a list of files from the data', () => {
     const result = recursionAnswers.listFiles(fileData);
     expect(result.length).to.eql(8);
-    expect(result.indexOf('index.html') > -1).to.be.ok();
-    expect(result.indexOf('main.js') > -1).to.be.ok();
-    expect(result.indexOf('underscore.js') > -1).to.be.ok();
+    expect(result.indexOf('index.html') > -1).to.be.ok;
+    expect(result.indexOf('main.js') > -1).to.be.ok;
+    expect(result.indexOf('underscore.js') > -1).to.be.ok;
   });
 
   it('you should be able to return a list of files in a subdir', () => {
     const result = recursionAnswers.listFiles(fileData, 'js');
     expect(result.length).to.eql(5);
-    expect(result.indexOf('main.js') > -1).to.be.ok();
-    expect(result.indexOf('underscore.js') > -1).to.be.ok();
+    expect(result.indexOf('main.js') > -1).to.be.ok;
+    expect(result.indexOf('underscore.js') > -1).to.be.ok;
   });
 
   it('you should be able to return the nth number in a fibonacci sequence', () => {


### PR DESCRIPTION
Hi! Currently, there's a bit of unexpected behavior when running through the tests.

<img width="467" alt="screen shot 2017-08-01 at 8 49 40 pm" src="https://user-images.githubusercontent.com/123075/28854362-63f82d10-76fc-11e7-9d09-08b41f7af395.png">

I had to go into the tests and correct the `.ok()` to be `.ok`, but that didn't sit right with me. git blame told me 15be04c1, run by the linter, changed things around

<img width="1396" alt="screen shot 2017-08-01 at 8 51 33 pm" src="https://user-images.githubusercontent.com/123075/28854409-96c21314-76fc-11e7-8930-50d7f4de50c3.png">

If I simply changed them back to being `.ok`, the next time the linter runs it'll change it right back. 

There seemed to be two different options:

1. add the comment to each place `.ok` is used: `expect(foo).to.be.ok; // eslint-disable-line no-unused-expressions `
2. Use the plugin `eslint-plugin-chai-friendly`

I chose the plugin route but could change to the inline comments if you'd rather have that. 


See: https://www.npmjs.com/package/eslint-plugin-chai-friendly